### PR TITLE
Adding double quotes to the JSON section of your `README.md` to have double quotes for it to be valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The plugin looks for a configuration file in your home directory called
 `.chatgpt-nvim.json`, and it expects a valid OpenAI api key to be set for
 queries to work:
 
-```
-{ 'api_key': '<API-KEY>' }
+```json
+{ "api_key": "<API-KEY>" }
 ```
 
 You can get an api key from OpenAI via their [website](https://platform.openai.com/account/api-keys).


### PR DESCRIPTION
Strings in JSON are specified using double quotes, i.e., " . If the strings are enclosed using single quotes, then the JSON is an invalid JSON file.