### PR TITLE
Packer on `.0.8.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ use({
   run = 'pip3 install -r requirements.txt'
 })
 ```
+I suggest using `NeoVim 0.8.0` as this comes with Packer by default. So pull NeoVim from an older tree:
+
+```bash
+git clone https://github.com/neovim/neovim/tree/v0.8.0
+``` 
 
 ### Configuration
 


### PR DESCRIPTION
Hi @terror and friends, 

It would seem NeoVim/AstroNVim/LunarVim have all seemingly stopped using Packer and switched to Lazy. I personally haven't found a good way to install it via Lazy. `:PackerInstall` seems to be the only way that I've found that has worked after countless hours of config changes, possible workarounds, etc. As you can see I'm still using Packer. 

I have a local instance that has the exact same install instructions as the one in Docker (The NeoVim version in Docker is `0.8.0`, the one on local is newer, here are the results of the local NeoVim instance when I run `:PackerInstall`:

![Screenshot 2023-04-09 at 4 40 47 PM](https://user-images.githubusercontent.com/20936398/230801908-ce0d199f-1547-452a-b7aa-9d11c8d8404c.png)

I even coded out another `plugins.lua` file, that I put in `~/.config/nvim/lua/user/plugins.lua` that just served as a function of bootstrapping Packer: 

```lua
local fn = vim.fn
local install_path = fn.stdpath('data') .. '/site/pack/packer/opt/packer.nvim' -- The directory /site/pack/packer/share/packer.nvim is 
-- deprecated so using /opt 
if fn.empty(fn.glob(install_path)) > 0 then
 packer_bootstrap = fn.system({ 'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path })
end

return require('packer').startup(function(use)
 use "wbthomason/packer.nvim"
-- All my plugins here
-- Automatically set up configuration after cloning packer.nvim
 if packer_bootstrap then
   require('packer').sync()
 end
end)
```

This is when I'm running it in an older version of NeoVim in Docker, the command `ChatGPT [query]` actually works:

![Screenshot 2023-04-09 at 4 36 46 PM](https://user-images.githubusercontent.com/20936398/230801776-1e0d6180-ab98-4b0e-90bf-fd97c4127d10.png)

Me running: 

```bash
ChatGPT what is a heap feng shui?
```
Screenshot for the record:

![Screenshot 2023-04-09 at 5 36 21 PM](https://user-images.githubusercontent.com/20936398/230804408-62361039-7947-4071-a82d-6c8b75fa20d9.png)

The query response: 

![Screenshot 2023-04-09 at 5 37 18 PM](https://user-images.githubusercontent.com/20936398/230804428-7c2eb5b6-ed7a-44a4-9518-38c76f0dce2c.png)

Some people have been trying LunarVim, but their official documentation is outdated and still says one of their core plugins is Packer by @wbthomason:

![Screenshot 2023-04-09 at 5 47 11 PM](https://user-images.githubusercontent.com/20936398/230804975-1c3084aa-158f-4f05-9612-9506f9532e8e.png)

Just a heads up, this really confused me. LunarVim is in fact using Lazy. My suggestion is to maybe add a warning, or at least a suggestion. 

Cheers,
Montana Mendy